### PR TITLE
Base details endpoint for Venues

### DIFF
--- a/lib/foursquare_venue.rb
+++ b/lib/foursquare_venue.rb
@@ -1,6 +1,10 @@
 module Foursquare
   class Venue < Foursquare::Node
     #Venues
+    def details(venue_id)
+      perform_graph_request("venues/#{venue_id}", {})
+    end
+
     def add(params={})
       params = {:name => "",
                 :address => "",


### PR DESCRIPTION
Adds a method to just pull up the base details endpoint for a specific venue.  Found myself doing <code>Foursquare::Node.new(auth-token).perform_request("venues/venue_id")</code> quite a bit.

https://developer.foursquare.com/docs/venues/venues.html
