### PR TITLE
removed search param defaults

### DIFF
--- a/lib/foursquare_venue.rb
+++ b/lib/foursquare_venue.rb
@@ -9,7 +9,6 @@ module Foursquare
                 :state=>"California",
                 :zip=>"94108",
                 :phone=>"",
-                :ll => "37.792694,-122.409325",
                 :primaryCategoryId => "4bf58dd8d48988d1e1931735"}.merge!(params)
 
       perform_graph_request("venues/add", params, "post")
@@ -20,13 +19,7 @@ module Foursquare
     end
 
     def search(params={})
-      params = {:ll => "37.792694,-122.409325",
-                :llAcc => "100",
-                :alt => "0",
-                :altAcc=>"100",
-                :query=>"",
-                :limit=>"50",
-                :intent=>"checkin"}.merge!(params)
+      params = { :limit => "50" }.merge!(params)
 
       perform_graph_request("venues/search", params)
     end
@@ -62,7 +55,6 @@ module Foursquare
                 :state=>"California",
                 :zip=>"94108",
                 :phone=>"",
-                :ll => "37.792694,-122.409325",
                 :primaryCategoryId => "4bf58dd8d48988d1e1931735"}.merge!(params)
 
       perform_graph_request("venues/#{venue_id}/proposeedit", params, "post")


### PR DESCRIPTION
removed ll defaults from all actions; removed all defaults from search except limit=50

These defaults are interfering with browse by sw/ne/query behavior. The Foursquare API is confused when it sees both ll/radius and sw/ne params, so it returns zero matches. Eliminating the defaults allows the developer to customize parameters without interference.
