### PR TITLE
Empty Query String Parameters

### DIFF
--- a/lib/foursquare_node.rb
+++ b/lib/foursquare_node.rb
@@ -12,7 +12,7 @@ module Foursquare
       @query_string += "oauth_token=#{CGI.escape(@access_token)}" unless @access_token.empty?
 
       if method=="get"
-        params.each{|key, val| @query_string += "&#{key}=#{val}"}
+        params.each{|key, val| @query_string += "&#{key}=#{val}" unless val.blank?}
         url = URI.parse("#{@base_url}#{endpoint}#{@query_string}")
         request = Net::HTTP::Get.new("#{url.path}?#{url.query}",{"Content-Type"=>"text/json"})
       else


### PR DESCRIPTION
The api doesn't seem to like some query string parameters being sent with get requests. For example, not setting afterTimestamp on /checkins returns a 400 error.
